### PR TITLE
Add setuptools metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,3 +24,7 @@ name = "testpypi"
 url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
 explicit = true
+
+[tool.setuptools]
+py-modules = ["config_forge"]
+package-dir = {"" = "src"}


### PR DESCRIPTION
## Summary
- configure setuptools in `pyproject.toml`
- build wheel to confirm `config_forge.py` is included

## Testing
- `python -m build --wheel --no-isolation`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ca67a5d588328b7050d7ab34a4d63