### PR TITLE
Implement __len__ for configuration sets

### DIFF
--- a/src/config_forge.py
+++ b/src/config_forge.py
@@ -63,6 +63,11 @@ class ParamSet:
 
         raise NotImplementedError()
 
+    def __len__(self) -> int:
+        """Return the number of configurations contained in the set."""
+
+        return sum(1 for _ in self)
+
     def __or__(self, other: "ParamSet") -> "Union":
         """Return a :class:`Union` of ``self`` and ``other``."""
 
@@ -88,6 +93,11 @@ class Single(ParamSet):
 
         yield (self.name, self.cfg)
 
+    def __len__(self) -> int:
+        """Return the number of configurations in this set (always ``1``)."""
+
+        return 1
+
 
 class Union(ParamSet):
     """A configuration set produced by combining multiple sets."""
@@ -102,6 +112,11 @@ class Union(ParamSet):
 
         for cfg_set in self.others:
             yield from cfg_set
+
+    def __len__(self) -> int:
+        """Return the total number of configurations across all sets."""
+
+        return sum(len(cfg_set) for cfg_set in self.others)
 
 
 class Patch(ParamSet):
@@ -123,3 +138,8 @@ class Patch(ParamSet):
                 else:
                     new_name = f"{nm}{_name_separator}{p_name}"
                 yield new_name, deep_merge(cfg, d)
+
+    def __len__(self) -> int:
+        """Return the number of patched configurations."""
+
+        return len(self.base) * len(self.patches)

--- a/tests/test_config_forge.py
+++ b/tests/test_config_forge.py
@@ -47,3 +47,23 @@ def test_set_name_separator():
     patched = base.patch(p={"x": 2})
     assert list(patched) == [("b::p", {"x": 2})]
 
+
+def test_len_single():
+    cfg = cgen.Single("nm", {})
+    assert len(cfg) == 1
+
+
+def test_len_patch_and_union():
+    base = cgen.Single("b", {})
+    p1 = base.patch(p1={}, p2={})
+    p2 = base.patch(q1={})
+    union = p1 | p2
+    assert len(p1) == 2
+    assert len(union) == 3
+
+
+def test_len_patch_chain():
+    base = cgen.Single("b", {})
+    patched = base.patch(p1={}, p2={}).patch(q1={}, q2={})
+    assert len(patched) == 4
+


### PR DESCRIPTION
## Summary
- add `__len__` implementation to `ParamSet` and subclasses
- test length behaviour on single, patched and unioned config sets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cdfbbeaa083289f4bd4ccd780bfdc