### PR TITLE
Implement name_separator context manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install config-forge
 import config_forge as cforge
 
 # optionally change the separator used for generated names
-cforge.set_name_separator("__")
+cforge.set_name_separator("__")  # or use `name_separator("__")` as a context manager
 
 base = cforge.Single("foo", {"a": 10, "b": {"c": 20, "d": 30}, "c": "qux"})
 

--- a/src/config_forge.py
+++ b/src/config_forge.py
@@ -22,6 +22,7 @@ from abc import abstractmethod
 import copy
 from typing import Iterable
 from dataclasses import dataclass
+from contextlib import contextmanager
 
 
 _name_separator = "__"
@@ -39,6 +40,19 @@ def set_name_separator(sep: str):
 
     global _name_separator
     _name_separator = sep
+
+
+@contextmanager
+def name_separator(sep: str):
+    """Temporarily set the separator used for generating configuration names."""
+
+    global _name_separator
+    prev = _name_separator
+    _name_separator = sep
+    try:
+        yield
+    finally:
+        _name_separator = prev
 
 
 def deep_merge(a, b):

--- a/tests/test_config_forge.py
+++ b/tests/test_config_forge.py
@@ -48,6 +48,21 @@ def test_set_name_separator():
     assert list(patched) == [("b::p", {"x": 2})]
 
 
+def test_name_separator_context():
+    base = cgen.Single("b", {"x": 1})
+    with cgen.name_separator("::"):
+        assert list(base.patch(p={})) == [("b::p", {"x": 1})]
+    assert list(base.patch(p={})) == [("b__p", {"x": 1})]
+
+
+def test_name_separator_context_restores_previous():
+    cgen.set_name_separator("++")
+    base = cgen.Single("b", {"x": 1})
+    with cgen.name_separator("::"):
+        assert list(base.patch(p={})) == [("b::p", {"x": 1})]
+    assert list(base.patch(p={})) == [("b++p", {"x": 1})]
+
+
 def test_len_single():
     cfg = cgen.Single("nm", {})
     assert len(cfg) == 1


### PR DESCRIPTION
## Summary
- add `name_separator` context manager to temporarily set name separator
- mention context manager usage in README
- test context manager behaviour

## Testing
- `pip install pytest pytest-cov`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce3bb555483289b1a1e4d2add6e93