### PR TITLE
Add Remove dataclass for deleting keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ foo__aaa {'a': 10, 'b': {'x': 30}, 'c': 'qux'}
 - **Patch** – apply dictionary patches to each configuration in a set.
 - **Union** – combine multiple configuration sets into one.
 - **Replace** – fully replace a sub-dictionary when merging.
+- **Remove** – remove a key entirely during merging.
+
+```python
+import config_forge as cforge
+
+cfg = cforge.deep_merge({"a": 1, "b": 2}, {"a": cforge.Remove()})
+assert cfg == {"b": 2}
+```
 
 See `examples/example.py` for a full demonstration.
 

--- a/src/config_forge.py
+++ b/src/config_forge.py
@@ -35,6 +35,13 @@ class Replace:
     data: dict
 
 
+@dataclass
+class Remove:
+    """Wrapper used to drop a key during :func:`deep_merge`."""
+
+    pass
+
+
 def set_name_separator(sep: str):
     """Change the separator used when generating new configuration names."""
 
@@ -61,7 +68,10 @@ def deep_merge(a, b):
     if isinstance(a, dict) and isinstance(b, dict):
         out = copy.deepcopy(a)
         for k, v in b.items():
-            out[k] = deep_merge(out.get(k), v)
+            if isinstance(v, Remove):
+                out.pop(k, None)
+            else:
+                out[k] = deep_merge(out.get(k), v)
         return out
     if isinstance(b, Replace):
         b = b.data

--- a/tests/test_config_forge.py
+++ b/tests/test_config_forge.py
@@ -2,6 +2,7 @@ import pytest
 
 import config_forge as cgen
 
+
 @pytest.fixture(autouse=True)
 def reset_separator():
     yield
@@ -22,6 +23,13 @@ def test_deep_merge_replace():
     assert res == {"a": 1, "b": {"x": 5}}
 
 
+def test_deep_merge_remove():
+    a = {"a": 1, "b": {"c": 2, "d": 3}}
+    b = {"a": cgen.Remove(), "b": {"c": cgen.Remove()}}
+    res = cgen.deep_merge(a, b)
+    assert res == {"b": {"d": 3}}
+
+
 def test_patch_and_union():
     base = cgen.Single("base", {"a": 1})
     cfg = base.patch(first={"a": 2}) | base.patch(second={"a": 3})
@@ -36,9 +44,7 @@ def test_patch_chain():
     base = cgen.Single("base", {"a": 1})
     cfg = base.patch(p1={"a": 2}).patch(p2={"b": 3})
     result = list(cfg)
-    assert result == [
-        ("base__p1__p2", {"a": 2, "b": 3})
-    ]
+    assert result == [("base__p1__p2", {"a": 2, "b": 3})]
 
 
 def test_set_name_separator():
@@ -82,3 +88,8 @@ def test_len_patch_chain():
     patched = base.patch(p1={}, p2={}).patch(q1={}, q2={})
     assert len(patched) == 4
 
+
+def test_patch_remove():
+    base = cgen.Single("b", {"a": 1, "b": 2})
+    patched = base.patch(rm={"a": cgen.Remove()})
+    assert list(patched) == [("b__rm", {"b": 2})]


### PR DESCRIPTION
## Summary
- add `Remove` dataclass next to `Replace`
- allow `deep_merge` to drop keys using `Remove`
- document removal feature in the README
- test new key removal behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cece2025083289ef83c23d31ef2e1