### PR TITLE
Add mapping and filtering for ParamSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ foo__aaa {'a': 10, 'b': {'x': 30}, 'c': 'qux'}
 - **Union** – combine multiple configuration sets into one.
 - **Replace** – fully replace a sub-dictionary when merging.
 - **Remove** – remove a key entirely during merging.
+- **map** – transform each `(name, config)` pair in a set.
+- **filter** – drop pairs that don't satisfy a predicate.
 
 ```python
 import config_forge as cforge
@@ -60,6 +62,21 @@ assert cfg == {"b": 2}
 ```
 
 See `examples/example.py` for a full demonstration.
+
+## Mapping and filtering
+
+```python
+import config_forge as cforge
+
+cfgs = (
+    cforge.Single("b", {"x": 1})
+    .patch(p1={"x": 2}, p2={"x": 3})
+    .map(lambda n, c: (n.upper(), {"x": c["x"] * 2}))
+    .filter(lambda n, c: c["x"] > 4)
+)
+
+assert list(cfgs) == [("B__P2", {"x": 6})]
+```
 
 ## License
 

--- a/tests/test_config_forge.py
+++ b/tests/test_config_forge.py
@@ -93,3 +93,30 @@ def test_patch_remove():
     base = cgen.Single("b", {"a": 1, "b": 2})
     patched = base.patch(rm={"a": cgen.Remove()})
     assert list(patched) == [("b__rm", {"b": 2})]
+
+
+def test_map():
+    base = cgen.Single("b", {"x": 1})
+    patched = base.patch(p1={"x": 2}, p2={"x": 3})
+
+    def func(nm, cfg):
+        return nm.upper(), {"x": cfg["x"] * 2}
+
+    mapped = patched.map(func)
+    assert list(mapped) == [
+        ("B__P1", {"x": 4}),
+        ("B__P2", {"x": 6}),
+    ]
+    assert len(mapped) == 2
+
+
+def test_filter():
+    base = cgen.Single("b", {"x": 0})
+    patched = base.patch(**{f"v{i}": {"x": i} for i in range(3)})
+
+    filtered = patched.filter(lambda n, c: c["x"] % 2 == 0)
+    assert list(filtered) == [
+        ("b__v0", {"x": 0}),
+        ("b__v2", {"x": 2}),
+    ]
+    assert len(filtered) == 2


### PR DESCRIPTION
## Summary
- add `map` and `filter` methods on `ParamSet`
- implement `Mapped` and `Filtered` classes
- document new APIs in README
- test mapping and filtering behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cef361654832882725a3933dd0874